### PR TITLE
use relatedMessages instead of custom index

### DIFF
--- a/src/com/message-thread.js
+++ b/src/com/message-thread.js
@@ -14,7 +14,7 @@ module.exports = function (app, thread, opts) {
 function replies (app, thread) {
   // collect replies
   var r = []
-  ;(thread.replies || []).forEach(function(reply) {
+  ;(thread.related || thread.replies || []).forEach(function(reply) {
     r.push(com.message(app, reply))
     r.push(replies(app, reply))
   })

--- a/src/lib/ssb-manifest.js
+++ b/src/lib/ssb-manifest.js
@@ -20,6 +20,7 @@ module.exports = {
   getLatest: 'async',
   whoami: 'async',
   getLocal: 'async',
+  relatedMessages: 'async',
 
   // publishers
   add: 'async',

--- a/src/pages/message.js
+++ b/src/pages/message.js
@@ -4,18 +4,25 @@ var com = require('../com')
 var util = require('../lib/util')
 
 module.exports = function (app) {
-  app.ssb.phoenix.getThread(app.page.param, function (err, thread) {
+  app.ssb.relatedMessages({
+    id: app.page.param, rel: 'replies-to',
+    count: true, parent: true
+  }, function (err, thread) {
     var content
     if (thread) {
       content = com.messageThread(app, thread, { fullLength: true })
-      app.ssb.phoenix.getPostParent(app.page.param, function (err, parent) {
-        if (parent) {
-          var pauthor = parent.value.author
-          var header = content.querySelector('.panel-heading .in-response-to')
-          header.appendChild(h('span', {innerHTML: ' &middot; in response to '}))
-          header.appendChild(com.a('#/msg/'+parent.key, 'a post by ' + (app.names[pauthor] || util.shortString(pauthor))))
-        }
-      })
+      try {
+        var pkey = thread.value.content.repliesTo.msg
+        app.ssb.get(pkey, function (err, parent) {
+          if (parent) {
+            var pauthor = parent.author
+            var header = content.querySelector('.panel-heading .in-response-to')
+            header.appendChild(h('span', {innerHTML: ' &middot; in response to '}))
+            header.appendChild(com.a('#/msg/'+pkey, 'a post by ' + (app.names[pauthor] || util.shortString(pauthor))))
+          }
+        })
+      }
+      catch (_) {}
     } else {
       content = 'Message not found.'
     }


### PR DESCRIPTION
This pull request paves the cowpath of the custom index defined by phoenix-api, by using the new generic query defined in secure-scuttlebutt.

Also, removed getParentPost wasn't necessary... we can just use an ordinary `get` here,
because we already have the content of the message.
I just grabbed the top level `repliesTo.msg` link, since post messages have a standard structure.

I think if we replaced the way reply counts are gotten for the inbox we could ditch the thread indexes entirely.