### PR TITLE
at-mentions now leave original text as-is and puts nicknames in the mention links

### DIFF
--- a/src/com/advert-form.js
+++ b/src/com/advert-form.js
@@ -10,8 +10,6 @@ module.exports = function (app) {
   // markup
 
   var textarea = h('textarea.form-control', { name: 'text', rows: 3, onblur: renderPreview })
-  suggestBox(textarea, app.suggestOptions) // decorate with suggest box
-
   var preview = h('.preview.well.well-sm.col-xs-3')
   var form = h('form.advert-form', { onsubmit: post },
     h('.open',
@@ -25,7 +23,7 @@ module.exports = function (app) {
   // event handlers
 
   function renderPreview (e) {
-    preview.innerHTML = markdown.block(textarea.value, app.names)
+    preview.innerHTML = markdown.block(textarea.value)
   }
 
   function post (e) {

--- a/src/com/message-summary.js
+++ b/src/com/message-summary.js
@@ -4,6 +4,7 @@ var mlib = require('ssb-msgs')
 var com = require('./index')
 var util = require('../lib/util')
 var markdown = require('../lib/markdown')
+var mentions = require('../lib/mentions')
 
 var attachmentOpts = { toext: true, rel: 'attachment' }
 module.exports = function (app, msg, opts) {
@@ -21,7 +22,7 @@ module.exports = function (app, msg, opts) {
   }
   content = util.escapePlain(content)
   content = markdown.emojis(content)
-  content = markdown.mentionLinks(content, app.names, true)
+  content = mentions.post(content, app, msg, true)
 
   var len = noHtmlLen(content)
   if (len > 60 || content.length > 512) {

--- a/src/com/message.js
+++ b/src/com/message.js
@@ -4,6 +4,7 @@ var mlib = require('ssb-msgs')
 var com = require('./index')
 var util = require('../lib/util')
 var markdown = require('../lib/markdown')
+var mentions = require('../lib/mentions')
 
 module.exports = function (app, msg, opts) {
   var content
@@ -15,7 +16,7 @@ module.exports = function (app, msg, opts) {
       if ((!opts || !opts.fullLength) && md.length >= 512) {
         md = md.slice(0, 512) + '... [read more](#/msg/'+msg.key+')'
       }
-      content = h('div', { innerHTML: markdown.block(md, app.names) })
+      content = h('div', { innerHTML: mentions.post(markdown.block(md), app, msg) })
     } else {
       if (!opts || !opts.mustRender)
         return ''

--- a/src/lib/markdown.js
+++ b/src/lib/markdown.js
@@ -1,8 +1,6 @@
 'use strict'
 var emojiNamedCharacters = require('emoji-named-characters')
-var marked = require('marked');
-
-var mentionRegex = /(\s|>|^)@([A-z0-9\/=\.\+]+)/g;
+var marked = require('marked')
 
 marked.setOptions({
   gfm: true,
@@ -15,23 +13,9 @@ marked.setOptions({
   emoji: renderEmoji
 });
 
-exports.block = function(text, names, allowHtml) {
-  return mentionLinks(marked(text||'', {sanitize: !allowHtml}), names)
-}
-
-var mentionRegex = /(\s|>|^)@([^\s^<]+)/g;
-var mentionLinks =
-exports.mentionLinks = function (str, names, spansOnly) {
-  if (!names)
-    return str
-  return str.replace(mentionRegex, function(full, $1, $2) {
-    var name = names[$2]
-    if (!name)
-      return ($1||'') + '<abbr class="text-danger" title="User not found">@'+$2+'</abbr>'
-    if (spansOnly)
-      return ($1||'') + '<strong class="user-link">@'+(name||$2)+'</strong>'
-    return ($1||'') + '<a class="user-link" href="#/profile/'+$2+'">@' + name + '</a>'
-  })
+var markedOpts = {sanitize: true}
+exports.block = function(text) {
+  return marked(text||'', markedOpts)
 }
 
 var emojiRegex = /(\s|>|^)?:([A-z0-9_]+):(\s|<|$)/g;

--- a/src/lib/mentions.js
+++ b/src/lib/mentions.js
@@ -1,0 +1,55 @@
+var schemas = require('ssb-msg-schemas')
+var mlib = require('ssb-msgs')
+
+var mentionRegex = /(\s|>|^)@([^\s^<]+)/g;
+var replace =
+exports.replace = function (str, each, spansOnly) {
+  return str.replace(mentionRegex, function(full, $1, name) {
+    // give cb functions for found/notfound
+    return each(name, 
+      function (id, name) {
+        if (spansOnly)
+          return ($1||'') + '<strong class="user-link">@'+(name||id)+'</strong>'
+        return ($1||'') + '<a class="user-link" href="#/profile/'+id+'">@' + name + '</a>'
+      },
+      function () {
+        return ($1||'') + '<abbr class="text-danger" title="User not found">@'+name+'</abbr>'
+      }
+    )
+  })
+}
+
+var mentionOpts = { tofeed: true, rel: 'mentions' }
+exports.post = function (str, app, msg, spansOnly) {
+  var mentions = mlib.getLinks(msg.value.content, mentionOpts)
+  return replace(str, function (name, found, notfound) {
+    // find the id from the mention links
+    var id
+    if (schemas.isHash(name))
+      id = name
+    else {
+      for (var i = 0; i < mentions.length; i++) {
+        if (mentions[i].name === name) {
+          id = mentions[i].feed
+          break
+        }
+      }
+    }
+
+    // render
+    if (!id)
+      return notfound()
+    name = app.names[id] || name // try to use locally-assigned name
+    return found(id, name)
+  }, spansOnly)
+}
+
+exports.preview = function (str, nameList) {
+  return replace(str, function (name, found, notfound) {
+    if (schemas.isHash(name))
+      return found(name, name)
+    if (name in nameList)
+      return found(name, name)
+    return notfound()
+  }, true)
+}

--- a/src/pages/adverts.js
+++ b/src/pages/adverts.js
@@ -34,7 +34,7 @@ module.exports = function (app) {
         var author = ad.value.author
         return h('.col-xs-2',
           h('small', 'advert by ', com.userlink(author, app.names[author])),
-          h('.well.well-sm', { innerHTML: markdown.block(ad.value.content.text, app.names) })
+          h('.well.well-sm', { innerHTML: markdown.block(ad.value.content.text) })
         )
       }
     }

--- a/src/pages/ext.js
+++ b/src/pages/ext.js
@@ -103,7 +103,7 @@ function markdownExt (app) {
   var el = (as == 'md') ? h('.ext-markdown') : h('.ext-txt')
   fetch(app, function (err, blob) {
     if (as == 'md')
-      el.innerHTML = markdown.block(blob, app.names)
+      el.innerHTML = markdown.block(blob)
     else
       el.textContent = blob
   })


### PR DESCRIPTION
closes #303 

example message schema:

```js
{
  "type": "post",
  "text": "test post using the new mentions scheme @pfraze",
  "mentions": [
    {
      "feed": "kIetR4xx26Q2M62vG0tNrptJDFnxP0SexLHaOIkyy08=.blake2s",
      "rel": "mentions",
      "name": "pfraze"
    }
  ]
}
```