### PR TITLE
honor-system PMs, new compose form, and fixed page frame

### DIFF
--- a/less/bootstrap/forms.less
+++ b/less/bootstrap/forms.less
@@ -33,7 +33,6 @@ label {
   display: inline-block;
   max-width: 100%; // Force IE8 to wrap long content (see https://github.com/twbs/bootstrap/issues/13141)
   margin-bottom: 5px;
-  font-weight: bold;
 }
 
 

--- a/less/com/post-form-expandable.less
+++ b/less/com/post-form-expandable.less
@@ -1,0 +1,12 @@
+.post-form-expandable {
+  .compose-btn {
+    margin-bottom: 1em;
+  }
+  .post-form-container {
+    background: #fff;
+    &.collapsed {
+      height: 0;
+      overflow: hidden;
+    }
+  }
+}

--- a/less/com/post-form.less
+++ b/less/com/post-form.less
@@ -78,6 +78,7 @@
     }
   }
   .post-form-btns {
+    height: 30px;
     button, a {
       margin-right: 5px;
     }

--- a/less/com/post-form.less
+++ b/less/com/post-form.less
@@ -28,37 +28,25 @@
       }
     }
   }
+  input {
+    .phoenix-form-control();
+  }
   .post-form-textarea {
     textarea {
       display: block;
       width: 100%;
-      padding: @padding-base-vertical @padding-base-horizontal;
-      font-size: @font-size-base;
-      line-height: @line-height-base;
-      color: @input-color;
-      background-color: #fafafa;
-      background-image: none;
+      
+      .phoenix-form-control();
 
-      border: 1px solid @input-border;
-      border-radius: @input-border-radius;
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
       border-bottom-style: dashed;
       outline: none;
 
-      .box-shadow(inset 0 1px 1px rgba(0,0,0,.075));
-      .transition(~"background ease-in-out .15s, box-shadow ease-in-out .15s");
-
       position: relative;
       z-index: 1; // put higher than attachments bar below so that box shadow covers it
 
-      // Placeholder
       .placeholder();
-
-      &:focus {
-        background: #fff;
-        box-shadow: 0 2px 1px rgba(0,0,0,0.05);      
-      }
     }
   }
   .post-form-attachments {

--- a/less/home.less
+++ b/less/home.less
@@ -77,6 +77,7 @@
 @import "com/message-summary.less";
 @import "com/ext.less";
 @import "com/post-form.less";
+@import "com/post-form-expandable.less";
 @import "com/adverts.less";
 @import "com/advert-form.less";
 @import "com/profile-controls.less";

--- a/less/home.less
+++ b/less/home.less
@@ -50,6 +50,27 @@
 @import "bootstrap/utilities.less";
 @import "bootstrap/responsive-utilities.less";
 
+.phoenix-form-control() {
+  padding: @padding-base-vertical @padding-base-horizontal;
+  font-size: @font-size-base;
+  line-height: @line-height-base;
+  color: @input-color;
+  background-color: #fafafa;
+  background-image: none;
+
+  border: 1px solid @input-border;
+  border-radius: @input-border-radius;
+
+  .box-shadow(inset 0 1px 1px rgba(0,0,0,.075));
+  .transition(~"background ease-in-out .15s, box-shadow ease-in-out .15s");
+
+  &:focus {
+    background: #fff;
+    box-shadow: 0 2px 1px rgba(0,0,0,0.05);
+    border: 1px solid @input-border;    
+  }
+}
+
 // Phoenix styles
 @import "com/message.less";
 @import "com/message-thread.less";

--- a/less/home.less
+++ b/less/home.less
@@ -128,6 +128,9 @@ html {
   color: #fff;
   background: @brand-danger;
 }
+.overflow-scroll {
+  overflow-y: scroll;
+}
 #app-status {
   position: fixed;
   top: 30px;

--- a/less/variables.less
+++ b/less/variables.less
@@ -348,7 +348,7 @@
 
 // Basics of a navbar
 @navbar-height:                    50px;
-@navbar-margin-bottom:             @line-height-computed;
+@navbar-margin-bottom:             0; //@line-height-computed;
 @navbar-border-radius:             @border-radius-base;
 @navbar-padding-horizontal:        floor((@grid-gutter-width / 2));
 @navbar-padding-vertical:          ((@navbar-height - @line-height-computed) / 2);

--- a/less/variables.less
+++ b/less/variables.less
@@ -17,7 +17,7 @@
 @brand-primary:         #428bca;
 @brand-success:         #12b812;
 @brand-info:            #5bc0de;
-@brand-warning:         #f0ad4e;
+@brand-warning:         #333; //#f0ad4e;
 @brand-danger:          #d9534f;
 
 

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ var multicb    = require('multicb')
 var router     = require('phoenix-router')
 var pull       = require('pull-stream')
 var schemas    = require('ssb-msg-schemas')
+var mlib       = require('ssb-msgs')
 var com        = require('./com')
 var pages      = require('./pages')
 var util       = require('./lib/util')
@@ -36,6 +37,7 @@ module.exports = function (ssb) {
   app.setupRpcConnection = setupRpcConnection.bind(app)
   app.refreshPage        = refreshPage.bind(app)
   app.getOtherNames      = getOtherNames.bind(app)
+  app.isMsgForMe         = isMsgForMe.bind(app)
   app.showUserId         = showUserId.bind(app)
   app.setPendingMessages = setPendingMessages.bind(app)
   app.setStatus          = setStatus.bind(app)
@@ -173,6 +175,19 @@ function getOtherNames (profile) {
     add(profile.assignedBy[k].name)
   }
   return names
+}
+
+var mentionOpts = { tofeed: true, rel: 'mentions' }
+function isMsgForMe (msg) {
+  if (msg.value.content.private && msg.value.author != this.myid) {
+    var i, mentionLinks = mlib.getLinks(msg.value.content, mentionOpts)
+    for (i = 0; i < mentionLinks.length; i++) {
+      if (mentionLinks[i].feed === this.myid)
+        return true
+    }
+    return false
+  }
+  return true
 }
 
 function showUserId () { 

--- a/src/app.js
+++ b/src/app.js
@@ -28,6 +28,7 @@ module.exports = function (ssb) {
 
   // page behaviors
 
+  window.addEventListener('resize', resizePage.bind(app))
   window.addEventListener('hashchange', function() { app.refreshPage() })
   document.body.addEventListener('click', onClick(app))
 
@@ -85,6 +86,12 @@ function setupRpcConnection () {
     if (event.type == 'post' || event.type == 'notification')
       app.setPendingMessages(app.pendingMessages + 1)
   }))
+}
+
+function resizePage (e) {
+  Array.prototype.forEach.call(document.querySelectorAll('.overflow-scroll'), function (el) {
+    el.style.height = (window.innerHeight - 60) + 'px'
+  })
 }
 
 function refreshPage (e) {
@@ -283,4 +290,5 @@ function setPage (name, page, opts) {
     el.appendChild(com.page(this, name, page))
   else
     el.appendChild(h('#page.container-fluid.'+name+'-page', page))
+  resizePage()
 }

--- a/src/com/index.js
+++ b/src/com/index.js
@@ -60,6 +60,7 @@ exports.header = function (app) {
     h('.container-fluid', [
       h('.navbar-header', h('a.navbar-brand', { href: '#/' }, 'secure scuttlebutt')),
       h('ul.nav.navbar-nav', [
+        //h('li', h('a.btn.btn-primary.btn-strong', { href: '#/compose' }, 'compose')),
         h('li.hidden-xs', a('#/address-book', 'address book')),
         h('li.hidden-xs', a('#/profile/' + app.myid, app.names[app.myid]))
       ]),
@@ -86,8 +87,6 @@ exports.sidenav = function (app) {
   ]
 
   return h('.side-nav', [
-    h('p', h('a.btn.btn-primary.btn-strong', { href: '#/compose' }, 'new post')),
-    h('hr'),
     pages.map(function (page) {
       if (page == '-')
         return h('hr')
@@ -139,3 +138,4 @@ exports.messageThread = require('./message-thread')
 exports.messageSummary = require('./message-summary')
 exports.peers = require('./peers')
 exports.postForm = require('./post-form')
+exports.postFormExpandable = require('./post-form-expandable')

--- a/src/com/message-summary.js
+++ b/src/com/message-summary.js
@@ -6,21 +6,13 @@ var util = require('../lib/util')
 var markdown = require('../lib/markdown')
 var mentions = require('../lib/mentions')
 
-var mentionOpts = { tofeed: true, rel: 'mentions' }
 var attachmentOpts = { toext: true, rel: 'attachment' }
 module.exports = function (app, msg, opts) {
 
   // private-msg filter
 
-  if (msg.value.content.private && msg.value.author != app.myid) {
-    var i, mentionLinks = mlib.getLinks(msg.value.content, mentionOpts)
-    for (i = 0; i < mentionLinks.length; i++) {
-      if (mentionLinks[i].feed == app.myid)
-        break
-    }
-    if (i == mentionLinks.length)
-      return ''
-  }
+  if (!app.isMsgForMe(msg))
+    return ''
 
   // markup
 

--- a/src/com/message-summary.js
+++ b/src/com/message-summary.js
@@ -6,8 +6,21 @@ var util = require('../lib/util')
 var markdown = require('../lib/markdown')
 var mentions = require('../lib/mentions')
 
+var mentionOpts = { tofeed: true, rel: 'mentions' }
 var attachmentOpts = { toext: true, rel: 'attachment' }
 module.exports = function (app, msg, opts) {
+
+  // private-msg filter
+
+  if (msg.value.content.private && msg.value.author != app.myid) {
+    var i, mentionLinks = mlib.getLinks(msg.value.content, mentionOpts)
+    for (i = 0; i < mentionLinks.length; i++) {
+      if (mentionLinks[i].feed == app.myid)
+        break
+    }
+    if (i == mentionLinks.length)
+      return ''
+  }
 
   // markup
 

--- a/src/com/message.js
+++ b/src/com/message.js
@@ -8,6 +8,8 @@ var mentions = require('../lib/mentions')
 
 module.exports = function (app, msg, opts) {
   var content
+  if (!app.isMsgForMe(msg))
+    return
   if (opts && opts.raw) {
     content = messageRaw(app, msg)
   } else {

--- a/src/com/post-form-expandable.js
+++ b/src/com/post-form-expandable.js
@@ -12,8 +12,10 @@ module.exports = function (app, toggleBtn, parent, opts) {
     toggleBtn.classList.toggle('btn-strong')
     if (formContainer.classList.contains('collapsed'))
       toggleBtn.textContent = initBtnText
-    else
+    else {
       toggleBtn.textContent = 'Cancel'
+      form.querySelector('textarea').focus()
+    }
   }
   return h('.post-form-expandable', formContainer)
 }

--- a/src/com/post-form-expandable.js
+++ b/src/com/post-form-expandable.js
@@ -2,11 +2,13 @@ var h = require('hyperscript')
 var postForm = require('./post-form')
 
 module.exports = function (app, toggleBtn, parent, opts) {
+  var defaultToggleBtn = !toggleBtn
+  toggleBtn = toggleBtn || h('button.btn.btn-primary.btn-strong.compose-btn', 'Compose') 
   var initBtnText = toggleBtn.textContent
   var form = postForm(app, parent, opts)
-  var formContainer = h('.post-form-container', form)
+  var formContainer = h('.post-form-container', (defaultToggleBtn) ? toggleBtn : '', form)
 
-  if (localStorage.postFormExpanded != 1)
+  if (localStorage.postFormDraft == '')
     formContainer.classList.add('collapsed')
   update()
 

--- a/src/com/post-form-expandable.js
+++ b/src/com/post-form-expandable.js
@@ -5,16 +5,29 @@ module.exports = function (app, toggleBtn, parent, opts) {
   var initBtnText = toggleBtn.textContent
   var form = postForm(app, parent, opts)
   var formContainer = h('.post-form-container', form)
-  formContainer.classList.add('collapsed')
+
+  if (localStorage.postFormExpanded != 1)
+    formContainer.classList.add('collapsed')
+  update()
+
   toggleBtn.onclick = function (e) {
-    e.preventDefault()
+    e && e.preventDefault()
     formContainer.classList.toggle('collapsed')
-    toggleBtn.classList.toggle('btn-strong')
-    if (formContainer.classList.contains('collapsed'))
+    update()
+  }
+  
+  function update () {
+    if (formContainer.classList.contains('collapsed')) {
       toggleBtn.textContent = initBtnText
+      toggleBtn.classList.add('btn-strong')
+      localStorage.postFormExpanded = 0
+      localStorage.postFormDraft = form.querySelector('textarea').value = ''
+    }
     else {
       toggleBtn.textContent = 'Cancel'
+      toggleBtn.classList.remove('btn-strong')
       form.querySelector('textarea').focus()
+      localStorage.postFormExpanded = 1
     }
   }
   return h('.post-form-expandable', formContainer)

--- a/src/com/post-form-expandable.js
+++ b/src/com/post-form-expandable.js
@@ -1,0 +1,19 @@
+var h = require('hyperscript')
+var postForm = require('./post-form')
+
+module.exports = function (app, toggleBtn, parent, opts) {
+  var initBtnText = toggleBtn.textContent
+  var form = postForm(app, parent, opts)
+  var formContainer = h('.post-form-container', form)
+  formContainer.classList.add('collapsed')
+  toggleBtn.onclick = function (e) {
+    e.preventDefault()
+    formContainer.classList.toggle('collapsed')
+    toggleBtn.classList.toggle('btn-strong')
+    if (formContainer.classList.contains('collapsed'))
+      toggleBtn.textContent = initBtnText
+    else
+      toggleBtn.textContent = 'Cancel'
+  }
+  return h('.post-form-expandable', formContainer)
+}

--- a/src/com/post-form.js
+++ b/src/com/post-form.js
@@ -10,7 +10,7 @@ var util = require('../lib/util')
 var markdown = require('../lib/markdown')
 var mentions = require('../lib/mentions')
 
-module.exports = function (app, parent) {
+module.exports = function (app, parent, opts) {
 
   var attachments = []
   var namesList = {} // a name->name map for the previews
@@ -24,6 +24,7 @@ module.exports = function (app, parent) {
   var filesList = h('ul')
   var textarea = h('textarea', { name: 'text', placeholder: 'Compose your message', rows: 6, onkeyup: onPostTextChange })
   suggestBox(textarea, app.suggestOptions)
+  textarea.value = (opts && opts.value) ? opts.value : ''
   var postBtn = h('button.btn.btn-primary.btn-strong.pull-right', { disabled: true }, 'Post to All')
 
   var form = h('form.post-form' + ((!!parent) ? '.reply-form' : ''), { onsubmit: post },
@@ -50,7 +51,7 @@ module.exports = function (app, parent) {
       h('.panel-body', preview)
     ),
     h('hr'),
-    h('p.post-form-btns', postBtn, h('button.btn.btn-primary', { onclick: cancel }, 'Cancel'))
+    h('p.post-form-btns', postBtn, ((!!parent) ? h('button.btn.btn-primary', { onclick: cancel }, 'Cancel') : ''))
   )
 
   function disable () {

--- a/src/com/post-form.js
+++ b/src/com/post-form.js
@@ -19,6 +19,7 @@ module.exports = function (app, parent, opts) {
 
   // markup
 
+  var isPrivate = false
   var preview = h('.preview')
   var filesInput = h('input.hidden', { type: 'file', multiple: true, onchange: filesAdded })  
   var filesList = h('ul')
@@ -113,12 +114,14 @@ module.exports = function (app, parent, opts) {
         var post = (parent) ? schemas.schemas.replyPost(text, null, parent) : schemas.schemas.post(text)
         if (mentions.length) post.mentions = mentions
         if (extLinks.length) post.attachments = extLinks
+        if (isPrivate) post.private = true
         app.ssb.add(post, function (err) {
           app.setStatus(null)
           enable()
           if (err) swal('Error While Publishing', err.message, 'error')
           else {
-            if (parent)
+            localStorage.postFormDraft = ''
+            if (parent || window.location.hash == '#/')
               app.refreshPage()
             else
               window.location.hash = '#/'
@@ -221,8 +224,10 @@ module.exports = function (app, parent, opts) {
   function onPrivateChange (e) {
     if (e.target.checked) {
       postBtn.innerText = 'Post to Mentioned Users'
+      isPrivate = true
     } else {
       postBtn.innerText = 'Post to All'
+      isPrivate = false
     }
   }
 

--- a/src/com/post-form.js
+++ b/src/com/post-form.js
@@ -24,7 +24,7 @@ module.exports = function (app, parent, opts) {
   var filesList = h('ul')
   var textarea = h('textarea', { name: 'text', placeholder: 'Compose your message', rows: 6, onkeyup: onPostTextChange })
   suggestBox(textarea, app.suggestOptions)
-  textarea.value = (opts && opts.value) ? opts.value : ''
+  textarea.value = localStorage.postFormDraft || ((opts && opts.value) ? opts.value : '')
   var postBtn = h('button.btn.btn-primary.btn-strong.pull-right', { disabled: true }, 'Post to All')
 
   var form = h('form.post-form' + ((!!parent) ? '.reply-form' : ''), { onsubmit: post },
@@ -65,6 +65,7 @@ module.exports = function (app, parent, opts) {
   // handlers
 
   function onPostTextChange (e) {
+    localStorage.postFormDraft = textarea.value
     preview.innerHTML = mentions.preview(markdown.block(textarea.value), namesList)
     if (textarea.value.trim())
       enable()

--- a/src/pages/address-book.js
+++ b/src/pages/address-book.js
@@ -19,6 +19,7 @@ module.exports = function (app) {
     app.setPage('address-book', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
       h('.col-xs-10.col-md-8.overflow-scroll',
+        com.postFormExpandable(app),
         h('table.table.addresses',
           h('thead', h('tr', h('th', 'Name'), h('th', {width: '100'}), h('th.text-center', {width:'70'}, 'Follow'))),
           h('tbody', com.addresses(app, data[0], data[1], data[2]))

--- a/src/pages/address-book.js
+++ b/src/pages/address-book.js
@@ -18,7 +18,7 @@ module.exports = function (app) {
 
     app.setPage('address-book', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-8',
+      h('.col-xs-10.col-md-8.overflow-scroll',
         h('table.table.addresses',
           h('thead', h('tr', h('th', 'Name'), h('th', {width: '100'}), h('th.text-center', {width:'70'}, 'Follow'))),
           h('tbody', com.addresses(app, data[0], data[1], data[2]))

--- a/src/pages/adverts.js
+++ b/src/pages/adverts.js
@@ -17,6 +17,7 @@ module.exports = function (app) {
     app.setPage('feed', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
       h('.col-xs-10.col-md-11.overflow-scroll', 
+        com.postFormExpandable(app),
         com.advertForm(app),
         h('hr'),
         h('.row', content),

--- a/src/pages/adverts.js
+++ b/src/pages/adverts.js
@@ -16,7 +16,7 @@ module.exports = function (app) {
     var loadMoreBtn = (adverts.length === 30) ? h('p', h('button.btn.btn-primary.btn-block', { onclick: loadMore }, 'Load More')) : ''
     app.setPage('feed', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-11', 
+      h('.col-xs-10.col-md-11.overflow-scroll', 
         com.advertForm(app),
         h('hr'),
         h('.row', content),

--- a/src/pages/ext.js
+++ b/src/pages/ext.js
@@ -50,7 +50,7 @@ module.exports = function (app) {
 
     app.setPage('ext', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9', content),
+      h('.col-xs-10.col-md-9.overflow-scroll', content),
       h('.hidden-xs.hidden-sm.col-md-2',
         com.adverts(app),
         h('hr'),

--- a/src/pages/ext.js
+++ b/src/pages/ext.js
@@ -50,7 +50,7 @@ module.exports = function (app) {
 
     app.setPage('ext', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9.overflow-scroll', content),
+      h('.col-xs-10.col-md-9.overflow-scroll', com.postFormExpandable(app), content),
       h('.hidden-xs.hidden-sm.col-md-2',
         com.adverts(app),
         h('hr'),

--- a/src/pages/feed.js
+++ b/src/pages/feed.js
@@ -14,7 +14,7 @@ module.exports = function (app) {
     var content = h('.message-feed', msgs.map(function (msg) { return com.message(app, msg, rawOpts) }))
     app.setPage('feed', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9', content, loadMoreBtn),
+      h('.col-xs-10.col-md-9.overflow-scroll', content, loadMoreBtn),
       h('.hidden-xs.hidden-sm.col-md-2',
         com.adverts(app),
         h('hr'),

--- a/src/pages/feed.js
+++ b/src/pages/feed.js
@@ -10,11 +10,12 @@ module.exports = function (app) {
 
     // markup
 
+    var composeBtn = h('button.btn.btn-primary.btn-strong.compose-btn', 'Compose')   
     var loadMoreBtn = (msgs.length === 30) ? h('p', h('button.btn.btn-primary.btn-block', { onclick: loadMore }, 'Load More')) : ''
     var content = h('.message-feed', msgs.map(function (msg) { return com.message(app, msg, rawOpts) }))
     app.setPage('feed', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9.overflow-scroll', content, loadMoreBtn),
+      h('.col-xs-10.col-md-9.overflow-scroll', h('p', composeBtn), com.postFormExpandable(app, composeBtn), content, loadMoreBtn),
       h('.hidden-xs.hidden-sm.col-md-2',
         com.adverts(app),
         h('hr'),

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -198,7 +198,7 @@ module.exports = function (app) {
 
   app.setPage('help', h('.row',
     h('.col-xs-2.col-md-1', com.sidenav(app)),
-    h('.col-xs-7', content),
+    h('.col-xs-7.overflow-scroll', content),
     h('.col-xs-3.col-md-4', 
       h('ul.nav.nav-pills.nav-stacked', helpnav('#/help/'+(app.page.param||'intro'), [
         ['#/help/intro', 'About'],

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -198,7 +198,7 @@ module.exports = function (app) {
 
   app.setPage('help', h('.row',
     h('.col-xs-2.col-md-1', com.sidenav(app)),
-    h('.col-xs-7.overflow-scroll', content),
+    h('.col-xs-7.overflow-scroll', com.postFormExpandable(app), content),
     h('.col-xs-3.col-md-4', 
       h('ul.nav.nav-pills.nav-stacked', helpnav('#/help/'+(app.page.param||'intro'), [
         ['#/help/intro', 'About'],

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -30,10 +30,16 @@ module.exports = function (app) {
       }))
     }
 
+    var composeBtn = h('button.btn.btn-primary.btn-strong.compose-btn', 'Compose')
     var loadMoreBtn = (msgs.length === 30) ? h('p', h('button.btn.btn-primary.btn-block', { onclick: loadMore }, 'Load More')) : ''
     app.setPage('feed', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9', content, loadMoreBtn),
+      h('.col-xs-10.col-md-9',
+        h('p', composeBtn),
+        com.postFormExpandable(app, composeBtn),
+        content,
+        loadMoreBtn
+      ),
       h('.hidden-xs.hidden-sm.col-md-2',
         com.adverts(app),
         h('hr'),

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -34,7 +34,7 @@ module.exports = function (app) {
     var loadMoreBtn = (msgs.length === 30) ? h('p', h('button.btn.btn-primary.btn-block', { onclick: loadMore }, 'Load More')) : ''
     app.setPage('feed', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9',
+      h('.col-xs-10.col-md-9.overflow-scroll',
         h('p', composeBtn),
         com.postFormExpandable(app, composeBtn),
         content,

--- a/src/pages/message.js
+++ b/src/pages/message.js
@@ -29,7 +29,10 @@ module.exports = function (app) {
 
     app.setPage('message', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9.overflow-scroll', content),
+      h('.col-xs-10.col-md-9.overflow-scroll',
+        com.postFormExpandable(app),
+        content
+      ),
       h('.hidden-xs.hidden-sm.col-md-2',
         com.adverts(app),
         h('hr'),

--- a/src/pages/message.js
+++ b/src/pages/message.js
@@ -7,21 +7,25 @@ module.exports = function (app) {
   app.ssb.phoenix.getThread(app.page.param, function (err, thread) {
     var content
     if (thread) {
-      content = com.messageThread(app, thread, { fullLength: true })
-      if (thread.parent) {
-        app.ssb.phoenix.getPostParent(app.page.param, function (err, parent) {
-          var summary
-          if (parent) {
-            var pauthor = (app.names[parent.value.author] || util.shortString(parent.value.author))
-            if (parent.value.content.text)
-              summary = '^ ' + pauthor + ': "' + util.shortString(parent.value.content.text, 100) + '"'
-            else
-              summary = '^ '+parent.value.content.type+' message by ' + pauthor
-          } else {
-            summary = '^ parent message not yet received (' + thread.parent + ')'
-          }
-          content.querySelector('.in-response-to').appendChild(com.a('#/msg/'+thread.parent, summary))
-        })
+      if (app.isMsgForMe(thread)) {      
+        content = com.messageThread(app, thread, { fullLength: true })
+        if (thread.parent) {
+          app.ssb.phoenix.getPostParent(app.page.param, function (err, parent) {
+            var summary
+            if (parent) {
+              var pauthor = (app.names[parent.value.author] || util.shortString(parent.value.author))
+              if (parent.value.content.text)
+                summary = '^ ' + pauthor + ': "' + util.shortString(parent.value.content.text, 100) + '"'
+              else
+                summary = '^ '+parent.value.content.type+' message by ' + pauthor
+            } else {
+              summary = '^ parent message not yet received (' + thread.parent + ')'
+            }
+            content.querySelector('.in-response-to').appendChild(com.a('#/msg/'+thread.parent, summary))
+          })
+        }
+      } else {
+        content = h('p', com.icon('eye-close'), ' This is a private message which is not addressed to you.')
       }
     } else {
       content = 'Message not found.'

--- a/src/pages/message.js
+++ b/src/pages/message.js
@@ -29,7 +29,7 @@ module.exports = function (app) {
 
     app.setPage('message', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9', content),
+      h('.col-xs-10.col-md-9.overflow-scroll', content),
       h('.hidden-xs.hidden-sm.col-md-2',
         com.adverts(app),
         h('hr'),

--- a/src/pages/posts.js
+++ b/src/pages/posts.js
@@ -41,7 +41,7 @@ module.exports = function (app) {
     var loadMoreBtn = (msgs.length === 30) ? h('p', h('button.btn.btn-primary.btn-block', { onclick: loadMore, style: 'margin-bottom: 24px' }, 'Load More')) : ''
     app.setPage('posts', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9',
+      h('.col-xs-10.col-md-9.overflow-scroll',
         h('p',
           composeBtn,
           h('span#get-latest.hidden', h('button.btn.btn-primary', { onclick: app.refreshPage }, 'Get Latest'))

--- a/src/pages/posts.js
+++ b/src/pages/posts.js
@@ -37,12 +37,16 @@ module.exports = function (app) {
         )
       )
     )
-   
+    var composeBtn = h('button.btn.btn-primary.btn-strong.compose-btn', 'Compose')   
     var loadMoreBtn = (msgs.length === 30) ? h('p', h('button.btn.btn-primary.btn-block', { onclick: loadMore, style: 'margin-bottom: 24px' }, 'Load More')) : ''
     app.setPage('posts', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-10.col-md-9', 
-        h('p#get-latest.hidden', h('button.btn.btn-primary.btn-block', { onclick: app.refreshPage }, 'Get Latest')),
+      h('.col-xs-10.col-md-9',
+        h('p',
+          composeBtn,
+          h('span#get-latest.hidden', h('button.btn.btn-primary', { onclick: app.refreshPage }, 'Get Latest'))
+        ),
+        com.postFormExpandable(app, composeBtn),
         content,
         loadMoreBtn, 
         help

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -132,35 +132,37 @@ module.exports = function (app) {
     var loadMoreBtn = (msgs.length === 30) ? h('p', h('button.btn.btn-primary.btn-block', { onclick: loadMore, style: 'margin-bottom: 24px' }, 'Load More')) : ''    
     app.setPage('profile', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-8',
-        nameTrustDlg,
-        h('p', composeBtn),
-        com.postFormExpandable(app, composeBtn, null, { value: '@'+(app.names[pid] || pid)+' ' }),
-        msgfeed,
-        loadMoreBtn
-      ),
-      h('.col-xs-2.col-md-3.profile-controls',
-        h('.section',
-          h('h2', name, com.nameConfidence(pid, app), renameBtn),
-          h('p.text-muted', 'joined '+joinDate)
+      h('.col-xs-10.col-md-11.overflow-scroll',
+        h('.col-xs-9',
+          nameTrustDlg,
+          h('p', composeBtn),
+          com.postFormExpandable(app, composeBtn, null, { value: '@'+(app.names[pid] || pid)+' ' }),
+          msgfeed,
+          loadMoreBtn
         ),
-        h('.section', h('p', followBtn), h('p', trustBtn), h('p', flagBtn)),
-        (givenNames.length)
-          ? h('.section',
-            h('small', h('strong', 'Given names '), com.a('#/help/names', '?')), 
-            h('br'),
-            h('ul.list-unstyled', givenNames)
+        h('.col-xs-3.profile-controls',
+          h('.section',
+            h('h2', name, com.nameConfidence(pid, app), renameBtn),
+            h('p.text-muted', 'joined '+joinDate)
+          ),
+          h('.section', h('p', followBtn), h('p', trustBtn), h('p', flagBtn)),
+          (givenNames.length)
+            ? h('.section',
+              h('small', h('strong', 'Given names '), com.a('#/help/names', '?')), 
+              h('br'),
+              h('ul.list-unstyled', givenNames)
+            )
+            : '',
+          trusters.length  ? h('.section', h('small', h('strong.text-success', com.icon('ok'), ' Trusted by'), ' ', com.a('#/help/trust', '?')), h('br'), h('ul.list-unstyled', trusters)) : '',
+          flaggers.length  ? h('.section', h('small', h('strong.text-danger', com.icon('flag'), ' Flagged by'), ' ', com.a('#/help/trust', '?')), h('br'), h('ul.list-unstyled', flaggers)) : '',
+          follows.length   ? h('.section', h('small', h('strong', 'Follows'), ' ', com.a('#/help/contacts', '?')), h('br'), h('ul.list-unstyled', follows)) : '',
+          followers.length ? h('.section', h('small', h('strong', 'Followed by'), ' ', com.a('#/help/contacts', '?')), h('br'), h('ul.list-unstyled', followers)) : '',
+          trusts.length    ? h('.section', h('small', h('strong', 'Trusts'), ' ', com.a('#/help/trust', '?')), h('br'), h('ul.list-unstyled', trusts)) : '',
+          flags.length     ? h('.section', h('small', h('strong', 'Flags'), ' ', com.a('#/help/trust', '?')), h('br'), h('ul.list-unstyled', flags)) : '',
+          h('.section',
+            h('small', h('strong', 'Emoji fingerprint '), com.a('#/help/trust', '?')),
+            h('div', { innerHTML: com.toEmoji(pid) })
           )
-          : '',
-        trusters.length  ? h('.section', h('small', h('strong.text-success', com.icon('ok'), ' Trusted by'), ' ', com.a('#/help/trust', '?')), h('br'), h('ul.list-unstyled', trusters)) : '',
-        flaggers.length  ? h('.section', h('small', h('strong.text-danger', com.icon('flag'), ' Flagged by'), ' ', com.a('#/help/trust', '?')), h('br'), h('ul.list-unstyled', flaggers)) : '',
-        follows.length   ? h('.section', h('small', h('strong', 'Follows'), ' ', com.a('#/help/contacts', '?')), h('br'), h('ul.list-unstyled', follows)) : '',
-        followers.length ? h('.section', h('small', h('strong', 'Followed by'), ' ', com.a('#/help/contacts', '?')), h('br'), h('ul.list-unstyled', followers)) : '',
-        trusts.length    ? h('.section', h('small', h('strong', 'Trusts'), ' ', com.a('#/help/trust', '?')), h('br'), h('ul.list-unstyled', trusts)) : '',
-        flags.length     ? h('.section', h('small', h('strong', 'Flags'), ' ', com.a('#/help/trust', '?')), h('br'), h('ul.list-unstyled', flags)) : '',
-        h('.section',
-          h('small', h('strong', 'Emoji fingerprint '), com.a('#/help/trust', '?')),
-          h('div', { innerHTML: com.toEmoji(pid) })
         )
       )
     ))

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -128,10 +128,17 @@ module.exports = function (app) {
     // render page
     var name = app.names[pid] || util.shortString(pid)
     var joinDate = (profile) ? util.prettydate(new Date(profile.createdAt), true) : '-'
+    var composeBtn = h('button.btn.btn-primary.btn-strong.compose-btn', 'Compose')
     var loadMoreBtn = (msgs.length === 30) ? h('p', h('button.btn.btn-primary.btn-block', { onclick: loadMore, style: 'margin-bottom: 24px' }, 'Load More')) : ''    
     app.setPage('profile', h('.row',
       h('.col-xs-2.col-md-1', com.sidenav(app)),
-      h('.col-xs-8', nameTrustDlg, msgfeed, loadMoreBtn),
+      h('.col-xs-8',
+        nameTrustDlg,
+        h('p', composeBtn),
+        com.postFormExpandable(app, composeBtn, null, { value: '@'+(app.names[pid] || pid)+' ' }),
+        msgfeed,
+        loadMoreBtn
+      ),
       h('.col-xs-2.col-md-3.profile-controls',
         h('.section',
           h('h2', name, com.nameConfidence(pid, app), renameBtn),


### PR DESCRIPTION
this is a PR that accumulated ideas as it went; apologies for that

main addition is honor-system pms. this is a prototype feature to represent what encryption will provide.

![screen shot 2015-02-05 at 12 15 38 am](https://cloud.githubusercontent.com/assets/1270099/6055818/a939bc42-accc-11e4-8b1c-4b33b1a6cb76.png)

PMs are posts with `private: true`. phoenix won't show these messages to the user unless they are the author or are mentioned in the message.

![screen shot 2015-02-05 at 12 15 49 am](https://cloud.githubusercontent.com/assets/1270099/6055824/bd155028-accc-11e4-9e94-9b475769b146.png)

here's what you see if you're not an intended recipient:

![screen shot 2015-02-05 at 12 11 56 am](https://cloud.githubusercontent.com/assets/1270099/6055826/c833f7ac-accc-11e4-946d-07cf43f7e552.png)

of course, anybody could pull the logs in another application and see these messages. this is just a prototype so we can prepare the UX with encryption in mind

also, the compose form was made a page embed, and the ui frame now stays fixed