### PR TITLE
Dynamic manifest

### DIFF
--- a/html/home.html
+++ b/html/home.html
@@ -9,6 +9,7 @@
   <body class="monospace">
     <div id="app-status" class="container"></div>
     <div id="page-container"></div>
+    <script src="/manifest.js"></script>
     <script src="/js/sweet-alert.js"></script>
     <script src="/js/home.js"></script>
   </body>

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ exports.manifest    = api.manifest
 exports.permissions = api.permissions
 
 exports.init = function (server) {
-  server.on('request', stack(
+  server.http.use(stack(
     function (req, res, next) {
       // Local-host only
       if (req.socket.remoteAddress != '127.0.0.1') {

--- a/src/home.js
+++ b/src/home.js
@@ -3,7 +3,10 @@ var muxrpc     = require('muxrpc')
 var Serializer = require('pull-serializer')
 var auth       = require('ssb-domain-auth')
 
-var ssb        = muxrpc(require('./lib/ssb-manifest'), false, function (stream) { return Serializer(stream, JSON, {split: '\n\n'}) })()
+//the SSB_MANIFEST variable is created by /manifest.js
+//which is loaded before the javascript bundle.
+
+var ssb        = muxrpc(SSB_MANIFEST, false, function (stream) { return Serializer(stream, JSON, {split: '\n\n'}) })()
 var localhost  = require('ssb-channel').connect(ssb, 'localhost')
 var app        = require('./app')(ssb)
 


### PR DESCRIPTION
This changes how the manifest is loaded, so that plugins do not have to bundle their own manifest.
This approach is analogous to the way server side clients load the manifest, sbot writes the manifest file into an accessible location,
 and then applications load it `fs.readFileSync(~/.ssb/manifest.json)` 

This means that the manifest only needs to be maintained in one place,
and is generated as a result of what plugins you have, not a hand edited file.
