### PR TITLE
IPV6 Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ exports.init = function (server) {
   server.http.use(stack(
     function (req, res, next) {
       // Local-host only
-      if (req.socket.remoteAddress != '127.0.0.1') {
+      if ((req.socket.remoteAddress != '127.0.0.1') && (req.socket.remoteAddress != '::ffff:127.0.0.1')) {
         console.log('Remote access attempted by', req.socket.remoteAddress)
         res.writeHead(403)
         return res.end('Remote access forbidden')


### PR DESCRIPTION
node v0.12 and iojs v1.1.0 seem to be defaulting to IPV6 where possible.

This means the conditional to test for a local ip address fails and the user is unable to get into the app even though they are accessing from a local machine. 

This patch adds the conditional for the default local IP address of `::ffff:127.0.0.1` which is localhost in the IPV6 world. 



