### PR TITLE
Phoenix API refactor - needed updates, notifications, and durable storage

### DIFF
--- a/less/com/message-summary.less
+++ b/less/com/message-summary.less
@@ -28,31 +28,12 @@
   }
   td:nth-child(2) {
     position: relative;
+    border-left: 5px solid #bbb;
   }
   td:nth-child(4) {
     text-align: right;
     white-space: nowrap;
     background: #fafafa;
-  }
-
-  &:not(.read) {
-    td:nth-child(1) {
-      .glyphicon-triangle-bottom;
-      &::before {
-        .glyphicon;
-        color: #ccc;
-      }
-    }
-  }
-
-  &.subscribed {
-    // this icon will take precedence over the :not(.read) icon
-    td:nth-child(1) {
-      .glyphicon-star;
-      &::before {
-        .glyphicon;
-      }
-    }
   }
 
   &.initmsg td {
@@ -107,6 +88,18 @@
       &::before {
         color: lighten(rgb(121, 18, 18), 40%);
       }
+    }
+  }
+
+  &.read {
+    td:nth-child(2) {
+      border-left-color: #eee;
+    }
+  }
+
+  &.subscribed {
+    td:nth-child(2) {
+      border-left-color: rgb(255, 194, 0); // orangish gold
     }
   }
 

--- a/less/com/message-summary.less
+++ b/less/com/message-summary.less
@@ -49,21 +49,17 @@
   }
 
   &.subscribed {
-    td:nth-child(2)::after {
-      content: 'Subscribed to Replies';
-      font-weight: 100;
-      padding: 0.5em 1em;
-      display: block;
-      margin-top: 0.5em;
-      background: #aaa;
-      color: #fff;
-      border-radius: 3px;
+    td:nth-child(1) {
+      .glyphicon-star;
+      &::before {
+        .glyphicon;
+      }
     }
-    &.read {
+    /*&.read {
       td:nth-child(2)::after {
         background: #999;
       }
-    }
+    }*/
   }
 
   &.initmsg td {

--- a/less/com/message-summary.less
+++ b/less/com/message-summary.less
@@ -35,61 +35,78 @@
     background: #fafafa;
   }
 
-  &.read {
-    background: #f5f5f5;
-    .hover-menu a {
-      border-color: #ccc;
-    }
+  &:not(.read) {
     td:nth-child(1) {
-      color: #eee;
-    }
-    td:nth-child(4) {
-      background: #e0e0e0;
+      .glyphicon-triangle-bottom;
+      &::before {
+        .glyphicon;
+        color: #ccc;
+      }
     }
   }
 
   &.subscribed {
+    // this icon will take precedence over the :not(.read) icon
     td:nth-child(1) {
       .glyphicon-star;
       &::before {
         .glyphicon;
       }
     }
-    /*&.read {
-      td:nth-child(2)::after {
-        background: #999;
-      }
-    }*/
   }
 
   &.initmsg td {
     &:nth-child(1) {
       background: #333;
       border-color: #000;
-    }  
-  }
-  &.postmsg td {
-    &:nth-child(1) {
-      border-color: rgb(26, 102, 202);
-      background: #006EFF;
+      &::before {
+        color: lighten(#333, 33%);
+      }
     }
   }
   &.advertmsg td, &.namemsg td, &.pubmsg td {
     &:nth-child(1) {
       border-color: rgb(137, 30, 160);
       background: #B611DA;
+      &::before {
+        color: lighten(#B611DA, 33%);
+      }
+    }  
+  }
+  &.postmsg td {
+    &:nth-child(1) {
+      border-color: rgb(26, 102, 202);
+      background: #006EFF;
+      &::before {
+        color: lighten(#006EFF, 33%);
+      }
+    }
+  }
+  &.advertmsg td, &.namemsg td, &.pubmsg td {
+    &:nth-child(1) {
+      border-color: rgb(137, 30, 160);
+      background: #B611DA;
+      &::before {
+        color: lighten(#B611DA, 33%);
+      }
     }
   }
   &.followmsg td, &.trustmsg td {
     &:nth-child(1) {
       border-color: rgb(19, 115, 16);
       background: #06AB01;
+      &::before {
+        color: lighten(#06AB01, 33%);
+      }
     }
   }
   &.unfollowmsg td, &.flagmsg td {
     &:nth-child(1) {
       border-color: rgb(121, 18, 18);
       background: rgb(208, 8, 8);
+      &::before {
+        color: lighten(rgb(121, 18, 18), 40%);
+      }
     }
   }
 

--- a/less/com/message-summary.less
+++ b/less/com/message-summary.less
@@ -24,11 +24,11 @@
     width: 30px;
     color: #fff;
     border-color: #555;
+    border-left: 5px solid #555;
     background: #808080;
   }
   td:nth-child(2) {
     position: relative;
-    border-left: 5px solid #bbb;
   }
   td:nth-child(4) {
     text-align: right;
@@ -92,13 +92,13 @@
   }
 
   &.read {
-    td:nth-child(2) {
+    td:nth-child(1) {
       border-left-color: #eee;
     }
   }
 
   &.subscribed {
-    td:nth-child(2) {
+    td:nth-child(1) {
       border-left-color: rgb(255, 194, 0); // orangish gold
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssbplug-phoenix",
   "description": "a web-interface plugin for scuttlebot",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "homepage": "https://github.com/ssbc/phoenix",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "multicb": "~1.1.0",
     "muxrpc": "~3.3.0",
     "once": "~1.3.1",
-    "phoenix-api": "~4.0.4",
+    "phoenix-api": "~5.0.0",
     "phoenix-router": "~1.0.0",
     "pretty-date": "0.2.0",
     "pull-merge": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "global": "~4.2.1",
     "hash-router": "~0.4.0",
     "hyperscript": "~1.4.3",
-    "level-js": "~2.1.6",
-    "level-sublevel": "~6.4.5",
     "marked": "git://github.com/clehner/marked#8af8ae018ba452b5c7f936a474dbce265f2ae732",
     "multiblob": "~1.4.1",
     "multicb": "~1.1.0",

--- a/src/app.js
+++ b/src/app.js
@@ -36,6 +36,7 @@ module.exports = function (ssb) {
   // toplevel & common methods
   app.setupRpcConnection = setupRpcConnection.bind(app)
   app.refreshPage        = refreshPage.bind(app)
+  app.updateCounts       = updateCounts.bind(app)
   app.getOtherNames      = getOtherNames.bind(app)
   app.showUserId         = showUserId.bind(app)
   app.setPendingCount    = setPendingCount.bind(app)
@@ -158,6 +159,14 @@ function refreshPage (e) {
   })
 }
 
+function updateCounts () {
+  var this_ = this
+  this_.ssb.phoenix.getIndexCounts(function (err, counts) {
+    console.log(counts)
+    this_.setInboxUnreadCount(counts.inboxUnread)
+  })
+}
+
 function getOtherNames (profile) {
   // todo - replace with ranked names
   var name = this.names[profile.id] || profile.id
@@ -201,8 +210,8 @@ function setPendingCount (n) {
 function setInboxUnreadCount (n) {
   this.indexCounts.inboxUnread = n
   try {
-    document.querySelector('.side-nav .inbox').textContent = 'Inbox ('+n+')'
-  } catch (e) {}  
+    document.querySelector('.side-nav .side-nav-inbox a').textContent = 'inbox ('+n+')'
+  } catch (e) { }  
 }
 
 function setStatus (type, message) {

--- a/src/app.js
+++ b/src/app.js
@@ -4,8 +4,6 @@ var multicb    = require('multicb')
 var router     = require('phoenix-router')
 var pull       = require('pull-stream')
 var schemas    = require('ssb-msg-schemas')
-var level      = require('level-js')
-var sublevel   = require('level-sublevel')
 var com        = require('./com')
 var pages      = require('./pages')
 var util       = require('./lib/util')
@@ -14,13 +12,8 @@ module.exports = function (ssb) {
 
   // master state object
 
-  var db = sublevel(level('phoenix'))
   var app = {
     ssb: ssb,
-    sys: db.sublevel('sys'),
-    accessTimesDb: db.sublevel('access_times'),
-    subscriptionsDb: db.sublevel('subscriptions'),
-    subscriptions: {}, // in-memory cache of subscriptions
     myid: null,
     names: null,
     nameTrustRanks: null,
@@ -106,12 +99,6 @@ function setupRpcConnection () {
     if (event.type == 'notification')
       app.setInboxUnreadCount(app.indexCounts.inboxUnread + 1)
   }))
-
-
-  // populate in-memory subscriptions cache
-  app.subscriptionsDb.createKeyStream().on('data', function (key) {
-    app.subscriptions[key] = true
-  })
 }
 
 function refreshPage (e) {

--- a/src/com/index.js
+++ b/src/com/index.js
@@ -81,7 +81,7 @@ exports.sidenav = function (app) {
   var pages = [
   //[id, path, label],
     ['posts', '', [icon('globe'), h('span', { style: 'padding-left: 2px' }, 'feed')]],
-    ['inbox', 'inbox', 'inbox ('+app.unreadMessages+')'],
+    ['inbox', 'inbox', 'inbox ('+app.indexCounts.inboxUnread+')'],
     ['compose', 'compose', 'compose'],
     ['address-book', 'address-book', 'users'],
     ['profile', 'profile/'+app.myid, app.names[app.myid] || 'profile'],

--- a/src/com/message-feed.js
+++ b/src/com/message-feed.js
@@ -191,6 +191,7 @@ module.exports = function (app, feedFn, filterFn, feedState) {
     app.ssb.phoenix.toggleRead(key, function (err, isRead) {
       if (err) return console.error(err)
       com.messageSummary.setRowState(rowEl, { read: isRead })
+      app.updateCounts()
     })
   }
 

--- a/src/com/message-thread.js
+++ b/src/com/message-thread.js
@@ -71,7 +71,7 @@ module.exports = function (app, thread, opts) {
     h('.attachments', attachments),
     h('ul.viewmode-select.list-inline', viewModes(thread, opts.viewMode)))
 
-  setSubscribeState()
+  app.ssb.phoenix.isSubscribed(thread.key, setSubscribeState)
   return h('.message-thread', threadInner, replies(app, thread, opts), h('p', subscribeBtn))
 
   // handlers
@@ -88,7 +88,7 @@ module.exports = function (app, thread, opts) {
   function onmarkunread (e) {
     e.preventDefault()
 
-    app.accessTimesDb.del(thread.key, function () {
+    app.ssb.phoenix.markUnread(thread.key, function () {
       window.location.hash = app.lastHubPage
     })
   }
@@ -96,18 +96,13 @@ module.exports = function (app, thread, opts) {
   function onsubscribe (e) {
     e.preventDefault()
 
-    if (app.subscriptions[thread.key])
-      app.subscriptionsDb.del(thread.key)
-    else
-      app.subscriptionsDb.put(thread.key, 1)
-    app.subscriptions[thread.key] = !app.subscriptions[thread.key]
-    setSubscribeState()
+    app.ssb.phoenix.toggleSubscribed(thread.key, setSubscribeState)
   }
 
   // ui state
 
-  function setSubscribeState () {
-    if (app.subscriptions[thread.key]) {
+  function setSubscribeState (err, subscribed) {
+    if (subscribed) {
       subscribeBtn.innerHTML = '&ndash; Unsubscribe from Replies'
     } else {
       subscribeBtn.innerText = '+ Subscribe to Replies'

--- a/src/com/post-form.js
+++ b/src/com/post-form.js
@@ -108,8 +108,7 @@ module.exports = function (app, parent) {
           if (err) swal('Error While Publishing', err.message, 'error')
           else {
             // auto-subscribe
-            app.subscriptionsDb.put(msg.key, 1)
-            app.subscriptions[msg.key] = true
+            app.ssb.phoenix.subscribe(msg.key)
 
             if (parent)
               app.refreshPage()

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -11,12 +11,6 @@ module.exports = function (app) {
   function filterFn (msg) {
     var c = msg.value.content
 
-    var hasLinksToUser = (mlib.getLinks(c, myfeedOpts).length > 0)
-    var parentLink = mlib.getLinks(c, { rel: 'replies-to', msg: true })[0]
-    var isSubscribedToParent = parentLink && app.subscriptions[parentLink.msg]
-    if (!(hasLinksToUser || isSubscribedToParent))
-      return false
-
     if (!queryStr)
       return true
 

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -42,7 +42,7 @@ module.exports = function (app) {
       h('p', 'When somebody @-mentions you or replies to your posts, you\'ll see their message here.')
     ]
   }*/
-  var content = com.messageFeed(app, filterFn)
+  var content = com.messageFeed(app, app.ssb.phoenix.createInboxStream, filterFn)
   var searchInput = h('input.search', { type: 'text', placeholder: 'Search', value: queryStr })
   app.setPage('feed', h('.row',
     h('.col-xs-2.col-md-1', com.sidenav(app)),

--- a/src/pages/message.js
+++ b/src/pages/message.js
@@ -15,7 +15,7 @@ module.exports = function (app) {
       content = com.messageThread(app, thread, {
         viewMode: app.page.qs.view || 'thread',
         onRender: function (msg) {
-          app.accessTimesDb.put(msg.key, Date.now())
+          app.ssb.phoenix.markRead(msg.key)
         }
       })
 

--- a/src/pages/message.js
+++ b/src/pages/message.js
@@ -16,6 +16,7 @@ module.exports = function (app) {
         viewMode: app.page.qs.view || 'thread',
         onRender: function (msg) {
           app.ssb.phoenix.markRead(msg.key)
+          app.updateCounts()
         }
       })
 

--- a/src/pages/posts.js
+++ b/src/pages/posts.js
@@ -34,7 +34,7 @@ module.exports = function (app) {
   // markup
 
   var searchInput = h('input.search', { type: 'text', placeholder: 'Search', value: queryStr })
-  var feed = com.messageFeed(app, filterFn, feedState)
+  var feed = com.messageFeed(app, app.ssb.createFeedStream, filterFn, feedState)
   app.setPage('posts', h('.row',
     h('.col-xs-1', com.sidenav(app)),
     h('.col-xs-9',

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -22,7 +22,7 @@ module.exports = function (app) {
     var profile = datas[2]
 
     // messages
-    var msgfeed = com.messageFeed(app, function (msg) {
+    var msgfeed = com.messageFeed(app, app.ssb.createFeedStream, function (msg) {
       return msg.value.author == pid
     })
 


### PR DESCRIPTION
This PR is going to track alongside https://github.com/ssbc/phoenix-api/pull/13

In addition to making necessary updates to phoenix-api, this PR is going to
 1. Fix the "unread messages count" on the inbox
 2. Move any code which uses indexeddb into `phoenix-api` where it may instead use sbot's leveldb instance (rationale explained here: https://github.com/ssbc/phoenix/issues/333)