### PR TITLE
hack to always allow vertical scroll events on message feed (so we can always load more)

### DIFF
--- a/src/com/message-feed.js
+++ b/src/com/message-feed.js
@@ -32,8 +32,8 @@ module.exports = function (app, feedFn, filterFn, feedState) {
       })   
     })
   }
-  feedContainer = h('.message-feed-container.full-height', h('table.message-feed', feedState.tbody))
 
+  feedContainer = h('.message-feed-container.full-height', h('table.message-feed', feedState.tbody))
   feedState.tbody.onclick = navtoMsg
   feedContainer.onscroll = onscroll
 
@@ -168,8 +168,9 @@ module.exports = function (app, feedFn, filterFn, feedState) {
     if (feedContainer.offsetHeight + feedContainer.scrollTop >= feedContainer.scrollHeight) {
       fetchBack(30)
     }
-    else if (feedContainer.scrollTop === 0) {
+    else if (feedContainer.scrollTop <= 1) {
       fetchFront(30)
+      feedContainer.scrollTop = 1
     }
   }
 


### PR DESCRIPTION
This basically keeps the message feed from ever getting `scrollTop === 0` - instead, it stops at 1. Why? Because attempting to scroll vertically at 0 didnt fire the scroll event, so phoenix didnt get a chance to look for fresh messages.

This appears to solve that issue.