### PR TITLE
only show posts by people you follow in the main feed

### DIFF
--- a/src/pages/posts.js
+++ b/src/pages/posts.js
@@ -17,9 +17,15 @@ module.exports = function (app) {
   }
   lastQueryStr = queryStr
   lastList = list
+  var myprofile = app.profiles[app.myid]
 
   function filterFn (msg) {
+    var a = msg.value.author
     var c = msg.value.content
+
+    // filter out people not followed directly
+    if (a !== app.myid && (!myprofile.assignedTo[a] || !myprofile.assignedTo[a].following))
+      return false
 
     if (list == 'posts') {
       if (c.type !== 'post')
@@ -38,7 +44,7 @@ module.exports = function (app) {
     if (!queryStr)
       return true
 
-    var author = app.names[msg.value.author] || msg.value.author
+    var author = app.names[a] || a
     var regex = new RegExp(queryStr.replace(/\s/g, '|'))
     if (regex.exec(author) || regex.exec(c.type))
       return true


### PR DESCRIPTION
Sbot replicates the feeds of FoaFs so that you can see conversation in your wider community, and have the profiles of FoaFs available. This is a good thing.

However, as a user I'd expect the feed view to only show posts by people I explicitly follow. This PR applies that filter (only on the feed view). You would still see messages by FoaFs in...

 - your inbox, if they reply to you or mention you
 - thread views of messages they reply to
 - the foaf's profile page

@dominictarr sound good to you?