### PR TITLE
Fix "Get your id" button

### DIFF
--- a/src/app-ui/index.js
+++ b/src/app-ui/index.js
@@ -4,7 +4,7 @@ var schemas = require('ssb-msg-schemas')
 module.exports = function (phoenix) {
 
   phoenix.ui.showUserId = function () { 
-    swal('Here is your contact id', this.user.id)
+    swal('Here is your contact id', phoenix.user.id)
   }
 
   phoenix.ui.setStatus = function (type, message) {


### PR DESCRIPTION
This fixes an bug that was preventing the "Get your id" link from working for me. 
The function `phoenix.ui.showUserId` was accessing `this` which was the button's DOM element instead of the `phoenix` object.