### PR TITLE
Replace name-confirmation with follow-confirmation and name conflict detection

### DIFF
--- a/src/com/contact-listing.js
+++ b/src/com/contact-listing.js
@@ -29,8 +29,7 @@ module.exports = function (app, profile, follows, opts) {
     h('td.profpic', com.userHexagon(app, id, 60)),
     ((opts && opts.syncspinner) ? h('td', (!profile.self.name) ? h('.spinner.inline.small', h('.cube1'), h('.cube2')) : '') : ''),
     h('td.details',
-      h('p.name', 
-        h('strong', com.a('#/profile/'+id, app.users.names[id]||u.shortString(id, 20)), com.nameConfidence(id, app), ' ', renamebtn)),
+      h('p.name', h('strong', com.a('#/profile/'+id, app.users.names[id]||u.shortString(id, 20))), ' ', renamebtn),
       h('p',
         (otherNames.length)
           ? h('small.text-muted', 'aka ', otherNames.join(', '))

--- a/src/com/contact-plaque.js
+++ b/src/com/contact-plaque.js
@@ -44,7 +44,7 @@ module.exports = function (app, profile, graphs) {
   var joinDate = (profile && profile.createdAt) &&
     u.prettydate(new Date(profile.createdAt), true)
   var title = h('.title',
-    h('h2', name, com.nameConfidence(contactId, app)),
+    h('h2', name),
     (primary) ?
       h('h3', com.user(app, primary), '\'s feed') :
       '',

--- a/src/com/index.js
+++ b/src/com/index.js
@@ -15,17 +15,6 @@ exports.icon = function (i) {
   return h('span.glyphicon.glyphicon-'+i)
 }
 
-var nameConfidence =
-exports.nameConfidence = function (id, app) {
-  if (app.users.nameTrustRanks[id] !== 1) {
-    return [' ', h('a', 
-      { title: 'This name was self-assigned and needs to be confirmed.', href: '#/profile/'+id },
-      h('span.text-muted', icon('user'), '?')
-    )]
-  }
-  return ''
-}
-
 var userlink =
 exports.userlink = function (id, text, opts) {
   opts = opts || {}
@@ -36,7 +25,15 @@ exports.userlink = function (id, text, opts) {
 
 var user =
 exports.user = function (app, id) {
-  return [userlink(id, userName(app, id)), nameConfidence(id, app)]
+  var followIcon
+  if (id != app.user.id && (!app.user.profile.assignedTo[id] || !app.user.profile.assignedTo[id].following)) {
+    followIcon = [' ', h('a', 
+      { title: 'This is not somebody you follow.', href: '#/profile/'+id },
+      h('span.text-muted', icon('user'), '?')
+    )]
+  }
+
+  return [userlink(id, userName(app, id)), followIcon]
 }
 
 var userName =

--- a/src/com/message-thread.js
+++ b/src/com/message-thread.js
@@ -33,7 +33,7 @@ module.exports = function (app, thread, opts) {
   var msgThreadTop = h('.message-thread-top',
     h('ul.threadmeta.list-inline',
       h('li.hex', com.userHexagon(app, thread.value.author)),
-      h('li', com.userlink(thread.value.author, app.users.names[thread.value.author]), com.nameConfidence(thread.value.author, app)),
+      h('li', com.user(thread.value.author, app.users.names[thread.value.author])),
       h('li', com.a('#/msg/'+thread.key, u.prettydate(new Date(thread.value.timestamp), true), { title: 'View message thread' })),
       h('li', h('a', { href: '#', onclick: onreply }, 'reply')),
       // h('li.pull-right', subscribeBtn),

--- a/src/com/message-thread.js
+++ b/src/com/message-thread.js
@@ -33,7 +33,7 @@ module.exports = function (app, thread, opts) {
   var msgThreadTop = h('.message-thread-top',
     h('ul.threadmeta.list-inline',
       h('li.hex', com.userHexagon(app, thread.value.author)),
-      h('li', com.user(thread.value.author, app.users.names[thread.value.author])),
+      h('li', com.user(app, thread.value.author)),
       h('li', com.a('#/msg/'+thread.key, u.prettydate(new Date(thread.value.timestamp), true), { title: 'View message thread' })),
       h('li', h('a', { href: '#', onclick: onreply }, 'reply')),
       // h('li.pull-right', subscribeBtn),

--- a/src/com/message.js
+++ b/src/com/message.js
@@ -42,7 +42,7 @@ var messageShell = function (app, msg, content, opts) {
     com.userHexagon(app, msg.value.author),
     h('.panel-heading',
       h('ul.list-inline',
-        h('li', com.user(msg.value.author, app.users.names[msg.value.author])),
+        h('li', com.user(app, msg.value.author)),
         h('li', com.a('#/msg/'+msg.key, u.prettydate(new Date(msg.value.timestamp), true), { title: 'View message msg' })),
         h('li', h('a', { title: 'Reply', href: '#', onclick: onreply }, 'reply')),
         h('li.pull-right', h('a', { href: '/msg/'+msg.key, target: '_blank' }, 'as JSON')))),

--- a/src/com/message.js
+++ b/src/com/message.js
@@ -42,7 +42,7 @@ var messageShell = function (app, msg, content, opts) {
     com.userHexagon(app, msg.value.author),
     h('.panel-heading',
       h('ul.list-inline',
-        h('li', com.userlink(msg.value.author, app.users.names[msg.value.author]), com.nameConfidence(msg.value.author, app)),
+        h('li', com.user(msg.value.author, app.users.names[msg.value.author])),
         h('li', com.a('#/msg/'+msg.key, u.prettydate(new Date(msg.value.timestamp), true), { title: 'View message msg' })),
         h('li', h('a', { title: 'Reply', href: '#', onclick: onreply }, 'reply')),
         h('li.pull-right', h('a', { href: '/msg/'+msg.key, target: '_blank' }, 'as JSON')))),

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -49,9 +49,13 @@ module.exports = function (app) {
     var followers = Object.keys(graphs.follow).filter(function (id) { return graphs.follow[id][pid] })
     var flaggers = Object.keys(graphs.trust).filter(function (id) { return graphs.trust[id][pid] === -1 })
 
-    // name confidence controls
-    var nameTrustDlg
-    if (app.users.nameTrustRanks[pid] !== 1) {
+    // name conflict controls
+    var nameConflictDlg
+    var nameConflicts = []
+    for (var id in app.users.names)
+      if (id != pid && app.users.names[id] == app.users.names[pid])
+        nameConflicts.push(id)
+    if (nameConflicts.length && !isFollowing && app.users.nameTrustRanks[pid] !== 1) {
       var mutualFollowers = inEdges(graphs.follow, true, followedByMe)
       mutualFollowers = (mutualFollowers.length) ?
         h('p', h('strong', 'Mutual Followers:'), h('ul.list-inline', mutualFollowers)) :
@@ -60,13 +64,13 @@ module.exports = function (app) {
             'There is no information about this user.' :
             'Warning: This user is not followed by anyone you follow.')
 
-      nameTrustDlg = h('.well', { style: 'margin: 0 0 5px 62px; background: #fff' },
-        h('h3', { style: 'margin-top: 0' }, (!!app.users.names[pid]) ? 'Is this "'+app.users.names[pid]+'?"' : 'Who is this user?'),
-        h('p',
-          'Users whose names you haven\'t confirmed will have a ',
-          h('span.text-muted', com.icon('user'), '?'),
-          ' next to them.'
-        ),
+      nameConflictDlg = h('.well', { style: 'margin: 0 0 5px 62px; background: #fff' },
+        h('h3', { style: 'margin-top: 0' }, 'Name Conflict!'),
+        h('p', 'This is not the only user named "'+app.users.names[pid]+'," which may be a coincidence, or it may be the sign of an imposter! Make sure this is who you think it is before you follow them.'),
+        h('h4', 'How can I tell?'),
+        h('p', 'Check for mutual friends or warning flags. If you need to be sure, ask your friend for their contact ID. This user\'s contact ID is ', h('strong', pid)),
+        h('h4', 'Conflicting users:'),
+        h('ul', nameConflicts.map(function (id) { return h('li', com.user(app, id)) })),
         mutualFollowers,
         h('p', (!!app.users.names[pid]) ?
           [
@@ -128,7 +132,7 @@ module.exports = function (app) {
     app.setPage('profile', h('.row',
       h('.col-xs-1'),
       h('.col-xs-7',
-        nameTrustDlg,
+        nameConflictDlg,
         h('.header-ctrls', { style: 'margin: 3px 62px' },
           com.nav({
             current: view,

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -72,13 +72,7 @@ module.exports = function (app) {
         h('h4', 'Conflicting users:'),
         h('ul', nameConflicts.map(function (id) { return h('li', com.user(app, id)) })),
         mutualFollowers,
-        h('p', (!!app.users.names[pid]) ?
-          [
-            h('button.btn.btn-primary.btn-strong', { onclick: confirmName }, 'Use "'+app.users.names[pid]+'"'),
-            ' or ',
-            h('button.btn.btn-primary.btn-strong', { onclick: rename }, 'Choose Another Name')
-          ] :
-          h('button.btn.btn-primary', { onclick: rename }, 'Choose a Name')),
+        h('p', h('button.btn.btn-primary.btn-strong', { onclick: rename }, 'Choose Another Name')),
         h('small.text-muted', 'Beware of trolls pretending to be people you know!')
       )
     }
@@ -258,17 +252,6 @@ module.exports = function (app) {
     function rename (e) {
       e.preventDefault()
       app.ui.setNamePrompt(pid)
-    }
-
-    function confirmName (e) {
-      e.preventDefault()
-
-      app.ui.pleaseWait(true, 500)
-      schemas.addContact(app.ssb, pid, { name: app.users.names[pid] }, function (err) {
-        app.ui.pleaseWait(false)
-        if (err) swal('Error While Publishing', err.message, 'error')
-        else app.refreshPage()
-      })
     }
 
     function toggleFollow (e) {


### PR DESCRIPTION
Confirming other users' names was not particularly useful (in fact, it was tedious). This PR replaces name-confirmation.

 - Instead of showing the "Who is this?" icon next to name-unconfirmed users, it is shown next to unfollowed users. 
 - Instead of asking users to confirm the name, a dialog is only shown for non-followed users with names that conflict with other users' names.

![screen shot 2015-05-09 at 11 08 58 pm](https://cloud.githubusercontent.com/assets/1270099/7553043/6e162ea2-f6a0-11e4-9e58-1e5ff37da1ba.png)

Should be easier